### PR TITLE
Fix quiz: duplicate title and actionButton icon error

### DIFF
--- a/R/quiz.R
+++ b/R/quiz.R
@@ -395,11 +395,11 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           shiny::actionButton(
-            "choose_left", "",
-            class = left_class,
+            "choose_left",
             shiny::tagList(make_btn_content(
               left_activity, left_category, left_period, left_extra
-            ))
+            )),
+            class = left_class
           )
         } else {
           shiny::div(
@@ -418,11 +418,11 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           shiny::actionButton(
-            "choose_right", "",
-            class = right_class,
+            "choose_right",
             shiny::tagList(make_btn_content(
               right_activity, right_category, right_period, right_extra
-            ))
+            )),
+            class = right_class
           )
         } else {
           shiny::div(

--- a/vignettes/quiz_shinylive.qmd
+++ b/vignettes/quiz_shinylive.qmd
@@ -5,6 +5,14 @@ filters:
   - shinylive
 ---
 
+```{=html}
+<style>
+/* Hide the page-level title — the quiz app has its own heading */
+h1.title, .quarto-title h1, header#title-block-header,
+.page-header, article > h1:first-child { display: none !important; }
+</style>
+```
+
 ```{shinylive-r}
 #| standalone: true
 #| viewerHeight: 800
@@ -292,9 +300,9 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           actionButton(
-            "choose_left", "",
-            class = left_class,
-            tagList(make_btn_content(left_activity, left_category, left_period, left_extra))
+            "choose_left",
+            tagList(make_btn_content(left_activity, left_category, left_period, left_extra)),
+            class = left_class
           )
         } else {
           div(class = left_class,
@@ -309,9 +317,9 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           actionButton(
-            "choose_right", "",
-            class = right_class,
-            tagList(make_btn_content(right_activity, right_category, right_period, right_extra))
+            "choose_right",
+            tagList(make_btn_content(right_activity, right_category, right_period, right_extra)),
+            class = right_class
           )
         } else {
           div(class = right_class,


### PR DESCRIPTION
## Summary
- **Duplicate title**: Added CSS to hide the page-level `<h1>` title in `quiz_shinylive.qmd` — the quiz app's own `<h2>` heading already shows "Which Is Riskier?"
- **Icon error**: Fixed `actionButton()` calls where `tagList(btn_content)` was passed as a positional arg matching the `icon` parameter (3rd formal arg), causing `validateIcon()` to reject it (`shiny.tag.list` ≠ `shiny.tag`). Moved content into `label` instead. Fixed in both `R/quiz.R` and the embedded vignette code.

## Test plan
- [ ] `pkgload::load_all()` succeeds
- [ ] `launch_quiz()` renders questions without "Invalid icon" error
- [ ] Deployed shinylive page shows single heading, no duplicate title
- [ ] Quiz navigation (Start → questions → results) works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)