### PR TITLE
Fix quiz: duplicate title and actionButton icon error

### DIFF
--- a/R/quiz.R
+++ b/R/quiz.R
@@ -395,11 +395,11 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           shiny::actionButton(
-            "choose_left", "",
-            class = left_class,
+            "choose_left",
             shiny::tagList(make_btn_content(
               left_activity, left_category, left_period, left_extra
-            ))
+            )),
+            class = left_class
           )
         } else {
           shiny::div(
@@ -418,11 +418,11 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           shiny::actionButton(
-            "choose_right", "",
-            class = right_class,
+            "choose_right",
             shiny::tagList(make_btn_content(
               right_activity, right_category, right_period, right_extra
-            ))
+            )),
+            class = right_class
           )
         } else {
           shiny::div(

--- a/vignettes/quiz_shinylive.qmd
+++ b/vignettes/quiz_shinylive.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Which Is Riskier?"
+title: "Risk Quiz"
 format: html
 filters:
   - shinylive
@@ -292,9 +292,9 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           actionButton(
-            "choose_left", "",
-            class = left_class,
-            tagList(make_btn_content(left_activity, left_category, left_period, left_extra))
+            "choose_left",
+            tagList(make_btn_content(left_activity, left_category, left_period, left_extra)),
+            class = left_class
           )
         } else {
           div(class = left_class,
@@ -309,9 +309,9 @@ question_ui <- function(state) {
         class = "col-5",
         if (!revealed) {
           actionButton(
-            "choose_right", "",
-            class = right_class,
-            tagList(make_btn_content(right_activity, right_category, right_period, right_extra))
+            "choose_right",
+            tagList(make_btn_content(right_activity, right_category, right_period, right_extra)),
+            class = right_class
           )
         } else {
           div(class = right_class,


### PR DESCRIPTION
## Summary
- **Duplicate title**: Changed YAML `title` from "Which Is Riskier?" to "Risk Quiz" so it no longer duplicates the in-app `<h2>` heading
- **Icon error**: `actionButton("choose_left", "", class=..., tagList(...))` — the `tagList(...)` positionally matched the `icon` param (3rd arg of `actionButton`), but `shiny.tag.list` fails `validateIcon()`. Fixed by making `tagList(...)` the `label` arg instead. Applied to both `R/quiz.R` and embedded vignette code.

## Test plan
- [ ] `pkgload::load_all()` succeeds
- [ ] `launch_quiz()` renders questions without "Invalid icon" error
- [ ] Deployed page title is "Risk Quiz", not duplicate "Which Is Riskier?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)