### PR TITLE
Add fig-cap, fig-alt to all vignette plots and diagrams

### DIFF
--- a/vignettes/architecture.qmd
+++ b/vignettes/architecture.qmd
@@ -39,14 +39,20 @@ safe_tar_read <- function(name) {
 
 # Helper: emit mermaid diagram as a script/div pair so pandoc cannot
 # HTML-encode the arrows (-->) or wrap lines in <p> tags.
-emit_mermaid <- function(target_name, fallback_msg) {
+emit_mermaid <- function(target_name, fallback_msg, caption = NULL, alt_text = NULL) {
   diagram <- safe_tar_read(target_name)
   if (!is.null(diagram)) {
     id <- gsub("[^a-z0-9]", "", target_name)
-    cat(sprintf('<pre class="mermaid" id="%s"></pre>\n', id))
+    if (!is.null(caption)) cat('<figure role="figure">\n')
+    cat(sprintf('<pre class="mermaid" id="%s"', id))
+    if (!is.null(alt_text)) cat(sprintf(' aria-label="%s"', alt_text))
+    cat('></pre>\n')
     cat(sprintf('<script type="text/plain" data-mermaid="%s">\n', id))
     cat(diagram)
     cat("\n</script>\n")
+    if (!is.null(caption)) {
+      cat(sprintf('<figcaption>%s</figcaption>\n</figure>\n', caption))
+    }
   } else {
     cat(paste0("*", fallback_msg, "*\n"))
   }
@@ -89,7 +95,9 @@ Target counts update automatically when plan files change.
 
 ```{r pipeline, results='asis'}
 emit_mermaid("vig_arch_pipeline_diagram",
-             "Pipeline diagram not available. Run `targets::tar_make()` first.")
+             "Pipeline diagram not available. Run `targets::tar_make()` first.",
+             caption = "Figure 1: Data pipeline stages from raw Eurostat/CDC data through cleaning, decomposition, aggregation, and vignette output targets.",
+             alt_text = "Mermaid flowchart showing five pipeline stages: ingest, clean, decompose, aggregate, and vignette outputs, with target counts at each stage.")
 ```
 
 ## 2. Function Hierarchy
@@ -99,7 +107,9 @@ Click any function to view its documentation.
 
 ```{r concept, results='asis'}
 emit_mermaid("vig_arch_concept_diagram",
-             "Concept diagram not available. Run `targets::tar_make()` first.")
+             "Concept diagram not available. Run `targets::tar_make()` first.",
+             caption = "Figure 2: Exported functions grouped by category — risk data, conversion utilities, regional analysis, visualisation, and quiz.",
+             alt_text = "Mermaid diagram showing all exported functions organised into five categories with links to their documentation pages.")
 ```
 
 ## 3. User Journey
@@ -108,7 +118,9 @@ Which function should you start with? Follow the decision tree below.
 
 ```{r journey, results='asis'}
 emit_mermaid("vig_arch_user_journey_diagram",
-             "User journey diagram not available. Run `targets::tar_make()` first.")
+             "User journey diagram not available. Run `targets::tar_make()` first.",
+             caption = "Figure 3: Decision tree guiding users from their question (compare risks, explore regions, convert units) to the appropriate function.",
+             alt_text = "Mermaid decision tree flowchart with three entry points — compare risks, explore regions, convert units — leading to specific package functions.")
 ```
 
 ## 4. Developer Workflow
@@ -118,7 +130,9 @@ Steps 4--5 follow the RED-GREEN TDD cycle.
 
 ```{r developer, results='asis'}
 emit_mermaid("vig_arch_developer_diagram",
-             "Developer diagram not available. Run `targets::tar_make()` first.")
+             "Developer diagram not available. Run `targets::tar_make()` first.",
+             caption = "Figure 4: Nine-step contributor workflow from issue creation through TDD (steps 4–5), documentation, CI checks, and PR merge.",
+             alt_text = "Mermaid flowchart showing a nine-step development workflow: issue, branch, plan, RED test, GREEN implementation, refactor, document, check, and PR.")
 ```
 
 ## 5. Targets DAG
@@ -126,6 +140,8 @@ emit_mermaid("vig_arch_developer_diagram",
 Auto-generated dependency graph of the full targets pipeline.
 
 ```{r visnetwork}
+#| fig-cap: "Interactive dependency graph of the full targets pipeline. Nodes represent targets; edges show dependencies. Hover for details, drag to rearrange."
+#| fig-alt: "Interactive visNetwork graph showing the directed acyclic graph (DAG) of approximately 40 targets with colour-coded nodes for data, function, and vignette targets."
 vis <- safe_tar_read("vig_arch_tar_visnetwork")
 if (!is.null(vis)) vis
 ```

--- a/vignettes/introduction.qmd
+++ b/vignettes/introduction.qmd
@@ -102,6 +102,8 @@ Using [`plot_risks()`](../reference/plot_risks.html), we can see the relative ma
 
 ```{r, fig.width=10, fig.height=14, out.extra='style="background-color: #1a1a1a; padding: 10px; border-radius: 4px;"'}
 #| echo: false
+#| fig-cap: "Logarithmic risk ladder showing micromorts per activity, split by COVID-19 and other categories. Activities range from a chest X-ray (0.1 micromort) to BASE jumping (430 micromorts)."
+#| fig-alt: "Horizontal bar chart on a log scale showing micromorts for ~40 activities. COVID-19 risks (vaccination, infection by age) are grouped separately from other risks (transport, medical, recreational). Bars are coloured by category."
 print(safe_tar_read("vig_intro_risk_plot"))
 ```
 
@@ -111,6 +113,8 @@ For interactive exploration with hover details and category filtering, use [`plo
 
 ```{r}
 #| echo: false
+#| fig-cap: "Interactive version of the risk ladder with hover details and category filtering."
+#| fig-alt: "Interactive plotly bar chart of micromorts per activity with tooltips showing exact values, microlives, and source period."
 safe_tar_read("vig_intro_risk_plot_interactive")
 ```
 

--- a/vignettes/palatable_units.qmd
+++ b/vignettes/palatable_units.qmd
@@ -117,6 +117,8 @@ Spiegelhalter advocates for a **Logarithmic Risk Ladder**. This visualization he
 
 ```{r, fig.width=8, fig.height=14}
 #| echo: false
+#| fig-cap: "Spiegelhalter's logarithmic risk ladder placing activities from negligible (banana dose) to extreme (BASE jumping) on a unified scale."
+#| fig-alt: "Horizontal bar chart on log scale showing ~40 activities ordered by micromorts. Activities span 5 orders of magnitude from 0.001 to 430 micromorts, coloured by category."
 print(safe_tar_read("vig_palatable_risk_plot"))
 ```
 
@@ -128,6 +130,8 @@ For interactive exploration, use `plot_risks_interactive()` which provides:
 
 ```{r}
 #| echo: false
+#| fig-cap: "Interactive risk ladder with hover details, category filtering, and zoom."
+#| fig-alt: "Interactive plotly version of the risk ladder allowing users to hover for exact micromort values and filter categories via the legend."
 safe_tar_read("vig_palatable_risk_plot_interactive")
 ```
 

--- a/vignettes/regional_variation.qmd
+++ b/vignettes/regional_variation.qmd
@@ -134,6 +134,8 @@ The divergence became pronounced after 2005:
 
 ```{r, fig.width=8, fig.height=5}
 #| echo: false
+#| fig-cap: "Life expectancy trends in Western Europe diverged after 2005, with some regions stalling while others continued to improve."
+#| fig-alt: "Line chart of life expectancy over time for multiple Western European regions. Lines converge until ~2005, then diverge, with UK regions showing the slowest improvement."
 print(safe_tar_read("vig_regional_trends_plot"))
 ```
 

--- a/vignettes/risk_equivalence.qmd
+++ b/vignettes/risk_equivalence.qmd
@@ -76,6 +76,8 @@ if (!is.null(everyday)) {
 Everyday activities expressed in chest X-ray equivalents:
 
 ```{r everyday-chart, fig.width=8, fig.height=5}
+#| fig-cap: "Everyday activities expressed in chest X-ray equivalents, showing that a long-haul flight equals ~50 chest X-rays while a banana is negligible."
+#| fig-alt: "Horizontal bar chart comparing everyday activities to chest X-ray dose equivalents. Activities ordered from least to most radiation-equivalent, with blue bars."
 everyday <- safe_tar_read("vig_equiv_everyday")
 if (!is.null(everyday) && requireNamespace("plotly", quietly = TRUE)) {
   plotly::plot_ly(
@@ -107,6 +109,8 @@ Flying is a composite risk: crash + deep vein thrombosis (DVT) + cosmic radiatio
 ### By Duration
 
 ```{r flight-duration, fig.width=9, fig.height=5}
+#| fig-cap: "Stacked bar chart decomposing flight risk into crash, DVT, and cosmic radiation components across 2h, 5h, 8h, and 12h flights."
+#| fig-alt: "Stacked bar chart showing flight micromorts by duration. Crash risk is constant (~1 mm), DVT appears above 4 hours and grows nonlinearly, cosmic radiation increases linearly with duration."
 flight_data <- safe_tar_read("vig_equiv_flight_duration")
 if (!is.null(flight_data) && requireNamespace("plotly", quietly = TRUE)) {
   plotly::plot_ly(
@@ -233,6 +237,8 @@ if (!is.null(med)) {
 How many chest X-rays equal one CT scan?
 
 ```{r medical-exchange, fig.width=8, fig.height=4}
+#| fig-cap: "Medical procedures ranked by chest X-ray equivalents, showing that a CT abdomen equals ~200 chest X-rays."
+#| fig-alt: "Horizontal bar chart of medical radiation procedures in chest X-ray equivalents. Red bars show procedures from dental X-ray (lowest) to CT abdomen (highest, ~200 equivalents)."
 med <- safe_tar_read("vig_equiv_medical_focus")
 if (!is.null(med) && requireNamespace("plotly", quietly = TRUE)) {
   med <- med |>
@@ -284,6 +290,8 @@ if (!is.null(hedgeable)) {
 Flight risk decomposition showing hedgeable vs non-hedgeable portions:
 
 ```{r hedgeable-plot, fig.width=9, fig.height=5}
+#| fig-cap: "Flight risk decomposition by hedgeability: DVT risk (green, hedgeable via compression socks) vs crash and radiation (red, not hedgeable)."
+#| fig-alt: "Stacked bar chart of flight micromorts by duration, coloured green for hedgeable components (DVT) and red for non-hedgeable (crash, cosmic radiation). DVT dominates hedgeable risk on longer flights."
 flight_data <- safe_tar_read("vig_equiv_flight_duration")
 if (!is.null(flight_data) && requireNamespace("plotly", quietly = TRUE)) {
   flight_data <- flight_data |>
@@ -365,6 +373,8 @@ Key insight: 100 lifetime chest X-rays (10 micromorts) exceeds a 40-year X-ray t
 Cumulative radiation exposure over a 40-year career:
 
 ```{r radiation-timeline, fig.width=9, fig.height=6}
+#| fig-cap: "Cumulative radiation micromorts over a 40-year career for different exposure profiles, showing that 100 lifetime chest X-rays exceeds occupational exposure."
+#| fig-alt: "Line chart of cumulative micromorts vs years of exposure. Multiple lines for different radiation scenarios (dental, X-ray tech, CT patient, annual cosmic). Lines diverge over time showing compounding differences."
 timeline <- safe_tar_read("vig_radiation_timeline_data")
 if (!is.null(timeline) && requireNamespace("plotly", quietly = TRUE)) {
   plotly::plot_ly(


### PR DESCRIPTION
## Summary
- Added `fig-cap` and `fig-alt` to all 10 plots across 4 vignettes (introduction, risk_equivalence, palatable_units, regional_variation)
- Extended `emit_mermaid()` in architecture.qmd with `caption`/`alt_text` parameters using HTML `<figure>`/`<figcaption>` pattern
- Added captions and alt-text to all 5 architecture diagrams (4 mermaid + 1 visnetwork)

## Test plan
- [ ] `devtools::check()` passes with no new notes
- [ ] Vignette content audit shows all plots have fig-cap and fig-alt
- [ ] pkgdown site renders captions correctly under each figure
- [ ] Architecture mermaid diagrams render with `<figcaption>` elements

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)